### PR TITLE
Add Start Button to Begin Game

### DIFF
--- a/simon.html
+++ b/simon.html
@@ -11,8 +11,9 @@
 
 <body>
     <h1>Simon Says</h1>
-    <h3>Press any key to start the game</h3>
-    <h4></h4>
+    <h3>Press Start to Begin</h3>
+    <h4>High Score: 0</h4>
+    <button id="start-btn">Start Game</button>
     <p></p>
 
     <div class="main_box">

--- a/simon.js
+++ b/simon.js
@@ -12,13 +12,12 @@ let start = false;
 let level = 0;
 let highScore = 0; // High score variable
 
-document.addEventListener("keypress", function () {
-  if (start == false) {
+document.getElementById("start-btn").addEventListener("click", function () {
+  if (!start) {
     console.log("Game is started");
     start = true;
+    levelUp();
   }
-
-  levelUp();
 });
 
 function gameFlash(randBtn) {


### PR DESCRIPTION
Description
- Added a `Start Game` button to initiate the game instead of starting it on a keypress.
- The button (`#start-btn`) provides a more user-friendly interface, allowing players to control when the game begins.
- Updated the code to check if the game is already in progress; the `Start Game` button only initiates a new game when `Start` is 
 `false`.
  
This feature enhances usability by allowing players to begin each game session, especially for first-time users.
